### PR TITLE
Use Byte Length for Content Length calculation instead of String Length

### DIFF
--- a/lib/rstreamor/file.rb
+++ b/lib/rstreamor/file.rb
@@ -1,26 +1,29 @@
 module Rstreamor
   class File
-    attr_accessor :file
+    attr_reader :file
 
     def initialize(file)
-      self.file = file
+      @file = file
     end
 
     def data
-      if self.file.respond_to? :data
-        self.file.data
+      @data ||= if file.respond_to? :data
+        file.data
       else
-        self.file.read
+        file.read
       end
     end
 
     def content_type
-      self.file.content_type
+      file.content_type
     end
 
     def size
-      data.size
+      # Because of encoding, the string size might not match the stream size,
+      # and that may lead to files being truncated when served (i.e. this happens
+      # often for MP3 files, were the last few seconds of files longer than a minute
+      # gets trimmed).
+      @size ||= data.bytesize
     end
-
   end
 end

--- a/lib/rstreamor/request.rb
+++ b/lib/rstreamor/request.rb
@@ -1,18 +1,18 @@
 module Rstreamor
   class Request
-    attr_accessor :request, :file
+    attr_reader :request, :file
 
     def initialize(request, file)
-      self.request = request
-      self.file = file
+      @request = request
+      @file = file
     end
 
     def ranges
-      self.request.headers['HTTP_RANGE'].gsub('bytes=', '').split('-') if self.request.headers['HTTP_RANGE']
+      request.headers['HTTP_RANGE'].gsub('bytes=', '').split('-') if request.headers['HTTP_RANGE']
     end
 
     def upper_bound
-      ranges[1] ? ranges[1].to_i : self.file.data.size
+      ranges[1] ? ranges[1].to_i : file.size
     end
 
     def lower_bound
@@ -20,24 +20,23 @@ module Rstreamor
     end
 
     def range_header?
-      self.request.headers['HTTP_RANGE'].present?
+      request.headers['HTTP_RANGE'].present?
     end
 
     def file_content_type
-      self.file.content_type
+      file.content_type
     end
 
     def slice_file
-      if self.request.headers['HTTP_RANGE'].present?
-        self.file.data.byteslice(lower_bound, upper_bound)
+      if request.headers['HTTP_RANGE'].present?
+        file.data.byteslice(lower_bound, upper_bound)
       else
-        self.file.data
+        file.data
       end
     end
 
     def file_size
-      self.file.size
+      file.size
     end
-
   end
 end

--- a/lib/rstreamor/response.rb
+++ b/lib/rstreamor/response.rb
@@ -1,25 +1,25 @@
 module Rstreamor
   class Response
-    attr_accessor :request
+    attr_reader :request
 
     def initialize(request)
-      self.request = request
+      @request = request
     end
 
     def response_code
-      self.request.range_header? ? 206 : 200
+      request.range_header? ? 206 : 200
     end
 
     def content_length
-      if self.request.range_header?
-        (self.request.upper_bound - self.request.lower_bound).to_s
+      if request.range_header?
+        (request.upper_bound - request.lower_bound).to_s
       else
-        self.request.file.data.size
+        request.file_size
       end
     end
 
     def content_range
-      "bytes #{self.request.lower_bound}-#{self.request.upper_bound - 1}/#{self.request.file.data.size}"
+      "bytes #{ request.lower_bound }-#{ request.upper_bound - 1 }/#{ request.file_size }"
     end
 
     def accept_ranges
@@ -29,6 +29,5 @@ module Rstreamor
     def cache_control
       'no-cache'
     end
-
   end
 end


### PR DESCRIPTION
### Description
Because a string may have different encodings, the string size might not match the byte representation size. This is true always that the encoding is other than ASCII.

This error can be seen often for example with MP3 files.
<img width="471" alt="screen shot 2017-11-09 at 9 59 13 am" src="https://user-images.githubusercontent.com/7291751/32608030-a5a0cb92-c539-11e7-8611-8228cbc83d38.png">

### Fix
Make use of `String`'s `bytesize` method, instead of size, for content length calculation. 
Also refactored code to make sure it always uses this value instead of `String.size`, and added memoization in `File` methods so stream is read a single time.