### PR TITLE
The byte ranges in HTTP headers are inclusive

### DIFF
--- a/lib/rstreamor/request.rb
+++ b/lib/rstreamor/request.rb
@@ -29,7 +29,7 @@ module Rstreamor
 
     def slice_file
       if request.headers['HTTP_RANGE'].present?
-        file.data.byteslice(lower_bound, upper_bound)
+        file.data.byteslice(lower_bound..upper_bound)
       else
         file.data
       end

--- a/lib/rstreamor/request.rb
+++ b/lib/rstreamor/request.rb
@@ -12,7 +12,7 @@ module Rstreamor
     end
 
     def upper_bound
-      ranges[1] ? ranges[1].to_i : file.size
+      ranges[1] ? ranges[1].to_i : (file.size - 1)
     end
 
     def lower_bound

--- a/lib/rstreamor/response.rb
+++ b/lib/rstreamor/response.rb
@@ -19,7 +19,7 @@ module Rstreamor
     end
 
     def content_range
-      "bytes #{ request.lower_bound }-#{ request.upper_bound - 1 }/#{ request.file_size }"
+      "bytes #{request.lower_bound}-#{request.upper_bound}/#{request.file_size}"
     end
 
     def accept_ranges

--- a/lib/rstreamor/response.rb
+++ b/lib/rstreamor/response.rb
@@ -12,7 +12,7 @@ module Rstreamor
 
     def content_length
       if request.range_header?
-        (request.upper_bound - request.lower_bound).to_s
+        (request.upper_bound - request.lower_bound + 1).to_s
       else
         request.file_size
       end

--- a/lib/rstreamor/version.rb
+++ b/lib/rstreamor/version.rb
@@ -1,3 +1,3 @@
 module Rstreamor
-  VERSION = "0.2.4"
+  VERSION = "0.2.5"
 end


### PR DESCRIPTION
For instance a header of 'Range: bytes=0-1' should respond with 2
bytes not 1 (which is the case prior to this commit)