### PR TITLE
Add options to stream_file

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,16 @@ If you dont use Carrierwave as a file make sure your file method has the followi
 - #data
 - #content_type
 
+Optionally, you could send some params to the `stream` method like the following example:
+```ruby
+class VideosController < ApplicationController
+  include Rstreamor
+  def show
+    stream @resource.image_file, { x_sendfile: true, stream: true }
+  end
+end
+```
+
 Please note that if you don't specify any range request headers Rstreamor will return the whole file from byte 0 to EOF with status code *200*
 
 # What is a range request?
@@ -94,4 +104,3 @@ Content-Type:application/mp4
 - Bugfixes
 - Codestyle
 - Anything that improves this gem
-

--- a/lib/rstreamor/stream.rb
+++ b/lib/rstreamor/stream.rb
@@ -1,17 +1,22 @@
 module Rstreamor
   module Stream
-    def stream(file)
+    def stream(file, options = {})
       request_builder = Rstreamor::Request.new(request, Rstreamor::File.new(file))
       response_builder = Rstreamor::Response.new(request_builder)
       set_response_header(request_builder, response_builder)
-      stream_file(request_builder, response_builder)
+      stream_file(request_builder, response_builder, options)
     end
 
     private
 
-    def stream_file(request_builder, response_builder)
+    def stream_file(request_builder, response_builder, options)
       content = request_builder.slice_file
-      send_data content, type: request_builder.file_content_type, disposition: 'inline', status: response_builder.response_code
+
+      send_data(content, {
+        type: request_builder.file_content_type,
+        disposition: 'inline',
+        status: response_builder.response_code
+      }.merge(options))
     end
 
     def set_response_header(request_builder, response_builder)


### PR DESCRIPTION
This extends the `send_data` options form Rails.
Source:
```ruby
# File actionpack/lib/action_controller/metal/streaming.rb, line 112
def send_data(data, options = {}) #:doc:
  send_file_headers! options.dup
  render options.slice(:status, :content_type).merge(:text => data)
end
